### PR TITLE
Provide third party libraries for building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ jobs:
 
       - run: mkdir -p build/distributions
 
+      - run: curl --output - $SUPPORT_LIB_URI | openssl enc -d -aes-256-cbc -md sha512 -pbkdf2 -iter 100000 -salt -in - -out - -k $SUPPORT_LIB_PASSWORD | tar zxf -
+
       - run: sbt test
 
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ executors:
 jobs:
   build:
     executor: docker-default
+    environment:
+      AHF70_64_HOME=/tmp
     steps:
       - checkout
       - restore_cache:
@@ -19,7 +21,7 @@ jobs:
 
       - run: curl --output - $SUPPORT_LIB_URI | openssl enc -d -aes-256-cbc -md sha512 -pbkdf2 -iter 100000 -salt -in - -out - -k $SUPPORT_LIB_PASSWORD | tar zxf -
 
-      - run: sbt test
+      - run: sbt -Dcom.xmlcalabash.css.prince.exepath=/tmp test
 
       - when:
           condition:


### PR DESCRIPTION
The smoke test passes by virtue of lying about where the formatters are installed. They aren't.